### PR TITLE
Drivetrain Voltage Ramp

### DIFF
--- a/src/Commands/Drive/Drive.cpp
+++ b/src/Commands/Drive/Drive.cpp
@@ -14,6 +14,8 @@ void Drive::Initialize() {
 void Drive::Execute() {
     if(abs(Robot::oi->getdriver()->GetSmoothY(frc::GenericHID::JoystickHand::kLeftHand)) > 0.1 || abs(Robot::oi->getdriver()->GetSmoothY(frc::GenericHID::JoystickHand::kRightHand)) > 0.1)
         Robot::drivetrain->TeleOpDrive(-Robot::oi->getdriver()->GetSmoothY(frc::GenericHID::JoystickHand::kLeftHand), -Robot::oi->getdriver()->GetSmoothY(frc::GenericHID::JoystickHand::kRightHand));
+    else
+        Robot::drivetrain->TeleOpDrive(0,0);
     //motor feed safety
     frc::Wait(0.005);
 }

--- a/src/Subsystems/Drivetrain.cpp
+++ b/src/Subsystems/Drivetrain.cpp
@@ -36,6 +36,9 @@ Drivetrain::Drivetrain(lib612::DriveProfile* dp) : Subsystem("Drivetrain") {
     this->drive_rr->SetTalonControlMode(CANTalon::TalonControlMode::kFollowerMode);
     this->drive_rr->Set(PORTS::CAN::drive_talonMR);
 
+    this->drive_ml->SetVoltageRampRate(RAMP_RATE);
+    this->drive_mr->SetVoltageRampRate(RAMP_RATE);
+
     this->drive.reset(RobotMap::drive.get());
 
     //TODO: Are these being used?

--- a/src/Subsystems/Drivetrain.cpp
+++ b/src/Subsystems/Drivetrain.cpp
@@ -125,7 +125,15 @@ void Drivetrain::InitDefaultCommand() {
 }
 
 void Drivetrain::TeleOpDrive(double l, double r){
-    RobotMap::drive->TankDrive(Robot::oi->getdriver()->GetY(GenericHID::JoystickHand::kLeftHand), Robot::oi->getdriver()->GetY(GenericHID::JoystickHand::kRightHand));
+    if (l == 0 && r == 0) {
+        drive_ml->SetVoltageRampRate(0);
+        drive_mr->SetVoltageRampRate(0);
+        RobotMap::drive->TankDrive(0.0f,0.0f);
+    } else
+        RobotMap::drive->TankDrive(l,r);
+
+    drive_ml->SetVoltageRampRate(RAMP_RATE);
+    drive_mr->SetVoltageRampRate(RAMP_RATE);
 }
 
 Drivetrain::DRIVE_MODE Drivetrain::getDriveMode() {

--- a/src/Subsystems/Drivetrain.h
+++ b/src/Subsystems/Drivetrain.h
@@ -39,6 +39,7 @@ public:
     void setDriveMode(DRIVE_MODE mode);
     DRIVE_MODE getDriveMode();
 
+    double RAMP_RATE = 20;
 private:
     double pi = 3.141592653;
 };


### PR DESCRIPTION
#75 
Drivetrain now ramps at 20v/s. 

It is temporarily set to 0 if both left and right inputs are 0 during Teleop (non-PID) inputs.