### PR TITLE
Intake causes controller rumble on stall

### DIFF
--- a/src/Commands/Internal/IntakeFuel.cpp
+++ b/src/Commands/Internal/IntakeFuel.cpp
@@ -19,13 +19,13 @@ void IntakeFuel::Execute() {
         Robot::intake->Stop();
     }
 
-    if (RobotMap::intake_talon_left->GetOutputVoltage() > STALL_OUTPUT_THRESHOLD ||
-       (RobotMap::intake_talon_left->GetSetpoint() != 0 && RobotMap::intake_talon_left->GetOutputVoltage() < 0.1))
+    if (RobotMap::intake_talon_left->GetOutputCurrent() > STALL_OUTPUT_THRESHOLD ||
+       (RobotMap::intake_talon_left->GetSetpoint() != 0 && RobotMap::intake_talon_left->GetOutputCurrent() < 0.1))
        Robot::oi->getgunner()->SetRumble(GenericHID::kLeftRumble, 1.0);
     else Robot::oi->getgunner()->SetRumble(GenericHID::kLeftRumble, 0.0);
 
-    if (RobotMap::intake_talon_right->GetOutputVoltage() > STALL_OUTPUT_THRESHOLD ||
-       (RobotMap::intake_talon_right->GetSetpoint() != 0 && RobotMap::intake_talon_right->GetOutputVoltage() < 0.1))
+    if (RobotMap::intake_talon_right->GetOutputCurrent() > STALL_OUTPUT_THRESHOLD ||
+       (RobotMap::intake_talon_right->GetSetpoint() != 0 && RobotMap::intake_talon_right->GetOutputCurrent() < 0.1))
        Robot::oi->getgunner()->SetRumble(GenericHID::kRightRumble, 1.0);
     else Robot::oi->getgunner()->SetRumble(GenericHID::kRightRumble, 0.0);
 

--- a/src/Commands/Internal/IntakeFuel.cpp
+++ b/src/Commands/Internal/IntakeFuel.cpp
@@ -18,6 +18,17 @@ void IntakeFuel::Execute() {
     } else {
         Robot::intake->Stop();
     }
+
+    if (RobotMap::intake_talon_left->GetOutputVoltage() > STALL_OUTPUT_THRESHOLD ||
+       (RobotMap::intake_talon_left->GetSetpoint() != 0 && RobotMap::intake_talon_left->GetOutputVoltage() < 0.1))
+       Robot::oi->getgunner()->SetRumble(GenericHID::kLeftRumble, 1.0);
+    else Robot::oi->getgunner()->SetRumble(GenericHID::kLeftRumble, 0.0);
+
+    if (RobotMap::intake_talon_right->GetOutputVoltage() > STALL_OUTPUT_THRESHOLD ||
+       (RobotMap::intake_talon_right->GetSetpoint() != 0 && RobotMap::intake_talon_right->GetOutputVoltage() < 0.1))
+       Robot::oi->getgunner()->SetRumble(GenericHID::kRightRumble, 1.0);
+    else Robot::oi->getgunner()->SetRumble(GenericHID::kRightRumble, 0.0);
+
 }
 
 bool IntakeFuel::IsFinished() {

--- a/src/Commands/Internal/IntakeFuel.h
+++ b/src/Commands/Internal/IntakeFuel.h
@@ -14,4 +14,5 @@ public:
     void Interrupted() override;
 private:
     bool in;
+    float STALL_OUTPUT_THRESHOLD = 8.0;
 };

--- a/src/Commands/Internal/IntakeFuel.h
+++ b/src/Commands/Internal/IntakeFuel.h
@@ -14,5 +14,5 @@ public:
     void Interrupted() override;
 private:
     bool in;
-    float STALL_OUTPUT_THRESHOLD = 3.0;
+    float STALL_OUTPUT_THRESHOLD = 35.0;
 };

--- a/src/Commands/Internal/IntakeFuel.h
+++ b/src/Commands/Internal/IntakeFuel.h
@@ -14,5 +14,5 @@ public:
     void Interrupted() override;
 private:
     bool in;
-    float STALL_OUTPUT_THRESHOLD = 8.0;
+    float STALL_OUTPUT_THRESHOLD = 3.0;
 };


### PR DESCRIPTION
#87 

Activates on two conditions: voltage draw higher than STALL_OUTPUT_THRESHOLD (8V) or voltage draw lower than 0.1V when the motor should be moving. Please review these threshold constants.