### PR TITLE
Code for retuning shooter PID + working vision

### DIFF
--- a/src/Commands/Shooter/Shoot.cpp
+++ b/src/Commands/Shooter/Shoot.cpp
@@ -11,21 +11,21 @@ Shoot::Shoot(): Command() {
 // Called just before this Command runs the first time
 void Shoot::Initialize() {
     printf("Shoot init\n");
-    Robot::shooter->Spin(IDLE);
+    frc::SmartDashboard::PutNumber("Shooter Setpoint", 1000);
+    Robot::shooter->Spin(0);
 }
 
 // Called repeatedly when this Command is scheduled to run
 void Shoot::Execute() {
     if (-Robot::oi->getgunner()->GetY(frc::GenericHID::kLeftHand) > 0.02) {
         if (Robot::oi->getgunner()->GetStartButton())
-            Robot::shooter->Spin(START_MULTIPLIER * OPTIMAL_RPM * -Robot::oi->getgunner()->GetSmoothY(frc::GenericHID::kLeftHand));
+            Robot::shooter->Spin(frc::SmartDashboard::GetNumber("Shooter Setpoint", 1000) * 1.25);
         else
-            Robot::shooter->Spin(OPTIMAL_RPM * -Robot::oi->getgunner()->GetSmoothY(frc::GenericHID::kLeftHand));
+            Robot::shooter->Spin(frc::SmartDashboard::GetNumber("Shooter Setpoint", 1000));
         //Robot::shooter->Agitate();
     } else {
-        Robot::shooter->Spin(IDLE);
+        Robot::shooter->Spin(0);
     }
-
 }
 
 // Make this return true when this Command no longer needs to run execute()

--- a/src/Commands/Vision/AutoAlign.cpp
+++ b/src/Commands/Vision/AutoAlign.cpp
@@ -1,7 +1,7 @@
 #include "AutoAlign.h"
 
 AutoAlign::AutoAlign(HorizontalFind::Direction dir) {
-	//AddSequential(new HorizontalFind(dir));
-	//AddSequential(new HorizontalAlign());
-	AddSequential(new MoveToTarget(20));
+	AddSequential(new HorizontalFind(dir));
+	AddSequential(new HorizontalAlign(5));
+	//AddSequential(new MoveToTarget(20));
 }

--- a/src/Commands/Vision/HorizontalAlign.cpp
+++ b/src/Commands/Vision/HorizontalAlign.cpp
@@ -1,106 +1,114 @@
 #include "HorizontalAlign.h"
 
 HorizontalAlign::HorizontalAlign(float timeout, bool continuous) :
-		PIDCommand("AlignToTarget", 0.004, 0, 0) {
-	Requires(Robot::drivetrain.get());
-	SetTimeout(8);
+        PIDCommand("AlignToTarget", 0.003, 0.0, 0.0) {
+    //0.0006
+    Requires(Robot::drivetrain.get());
 
-	this->continuous = continuous;
+    this->continuous = continuous;
+    this->hasTarget = Robot::vision->UpdateCurrentTarget();
 
-	if(timeout != 0)
-		SetTimeout(timeout);
+    if(timeout != 0)
+        SetTimeout(timeout);
+    //SmartDashboard::PutNumber("dP", 0.004); SmartDashboard::PutNumber("dI",0.0); SmartDashboard::PutNumber("dD", 0.0);
 }
 
 void HorizontalAlign::Initialize() {
-	printf("Horizontal Align initialize\n");
-	auto pid = GetPIDController();
-	pid->SetAbsoluteTolerance(40);
-	pid->SetSetpoint(SCREEN_CENTER_X); //Point we're trying to get to
-	pid->Disable();
-	pid->SetOutputRange(-(ROT_SPEED_CAP - ROT_SPEED_MIN), ROT_SPEED_CAP - ROT_SPEED_MIN);
+    printf("Horizontal Align initialize\n");
+    auto pid = GetPIDController();
+    pid->SetAbsoluteTolerance(PIXEL_TOLERANCE);
+    pid->SetSetpoint(SCREEN_CENTER_X); //Point we're trying to get to
+    pid->SetOutputRange(-0.3, 0.3);
+    pid->Disable();
 }
 
 void HorizontalAlign::Execute() {
-	//Only if we need to FIND a target
-	if (!hasTarget) {
-        Robot::drivetrain->TankDrive(-1 * lastTargetDir, 1 * lastTargetDir);
-		hasTarget = Robot::vision->UpdateCurrentTarget();
-	}
-	else {
-		if (!GetPIDController()->IsEnabled()) {
-			PIDUserDisabled = false;
-			//GetPIDController()->SetPID(1, 0, 0);
-			auto pid = GetPIDController();
-			pid->SetPID(SmartDashboard::GetNumber("dP", 0.004), SmartDashboard::GetNumber("dI", 0), SmartDashboard::GetNumber("dD", 0));
-			pid->Enable();
-		}
-		else
-			printf("PID Enabled\n");
-	}
+    //Only if we need to FIND a target
+    hasTarget = Robot::vision->UpdateCurrentTarget();
+    if (!hasTarget) {
+        SmartDashboard::PutBoolean("Vision has target", hasTarget);
+        Robot::drivetrain->TankDrive(-0.1 * lastTargetDir, 0.1 * lastTargetDir);
+        hasTarget = Robot::vision->UpdateCurrentTarget();
+    }
+    else {
+        if (!GetPIDController()->IsEnabled()) {
+            PIDUserDisabled = false;
+            //GetPIDController()->SetPID(1, 0, 0);
+            auto pid = GetPIDController();
+            //pid->SetPID(SmartDashboard::PutNumber("dP", 0.004), SmartDashboard::PutNumber("dI",0.0), SmartDashboard::PutNumber("dD", 0.0));
+            pid->Enable();
+        }
+        else
+            printf("Info: Vision PID Enabled\n");
+    }
 }
 
 //Inherited from PID Command, returns the input from the vision targets
 double HorizontalAlign::ReturnPIDInput() {
-	//Makes sure that the target still exists, if not, it goes bye bye
-	std::shared_ptr<VisionTarget> target = Robot::vision->GetTrackedGoal();
-	if (target == nullptr) {
-		PIDUserDisabled = true;
-		hasTarget = false;
-		GetPIDController()->Disable();
-		return 0;
-	}
-	else {
-		int centerX = target->GetCenter().x;
-		printf("Center X %u\n", centerX);
+    //Makes sure that the target still exists, if not, it goes bye bye
+    std::shared_ptr<VisionTarget> target = Robot::vision->GetTrackedGoal();
+    if (target == nullptr) {
+        PIDUserDisabled = true;
+        hasTarget = false;
+        GetPIDController()->Disable();
+        return 0;
+    }
+    else {
+        int centerX = target->GetCenter().x;
+        SmartDashboard::PutNumber("Vision Center", target->GetCenter().x);
+        printf("Center X %u\n", centerX);
 
-		lastTargetDir = centerX < SCREEN_CENTER_X?-1:1;
-		lastCenter = centerX;
+        lastTargetDir = centerX < SCREEN_CENTER_X?-1:1;
+        lastCenter = centerX;
 
-		return (double) centerX;
-	}
+        return (double) centerX;
+    }
 }
 
 void HorizontalAlign::UsePIDOutput(double output) {
-	if (GetPIDController()->OnTarget()) {
-		onTargetCounter++;
-		if (onTargetCounter > 10) {
-			aligned = true;
+    if (GetPIDController()->OnTarget()) {
+        onTargetCounter++;
+        if (onTargetCounter > TICK_TOLERANCE) {
+            aligned = true;
             Robot::drivetrain->TankDrive(0, 0);
-			return;
-		}
-	}
-	else {
-		onTargetCounter = 0;
-	}
+            return;
+        }
+    }
+    else {
+        onTargetCounter = 0;
+    }
 
-	SmartDashboard::PutNumber("OnTarget Counter", onTargetCounter);
+    SmartDashboard::PutNumber("OnTarget Counter", onTargetCounter);
 
-	printf("%f", output);
+    printf("%f", output);
 
-	if (output > 0)
-		output += ROT_SPEED_MIN;
-	else if (output < 0)
-		output -= ROT_SPEED_MIN;
+    /*if (output > 0)
+        output += ROT_SPEED_MIN;
+    else if (output < 0)
+        output -= ROT_SPEED_MIN;*/
 
-	if (!PIDUserDisabled && !IsFinished())
+    if (!PIDUserDisabled && !IsFinished())
         Robot::drivetrain->TankDrive(output, -output);
-	//printf("\noutput");
+    //printf("\noutput");
 
-	SmartDashboard::PutNumber("AutoAlign Output", output);
-
-	printf("wowowow %f, %u\n" , output, PIDUserDisabled);
+    SmartDashboard::PutNumber("AutoAlign Output", output);
+    printf("wowowow %f, %u\n" , output, PIDUserDisabled);
 }
 
 bool HorizontalAlign::IsFinished() {
-	return !continuous && aligned;
+    if(IsTimedOut()) {
+        std::cout << "Warning: Horizontal Align timed out" << std::endl;
+        return true;
+    }
+    return !continuous && aligned;
 }
 
 void HorizontalAlign::End() {
-	GetPIDController()->Disable();
+    GetPIDController()->Disable();
     Robot::drivetrain->TankDrive(0, 0);
 }
 
 void HorizontalAlign::Interrupted() {
-	GetPIDController()->Disable();
+    GetPIDController()->Disable();
     Robot::drivetrain->TankDrive(0, 0);
 }

--- a/src/Commands/Vision/HorizontalAlign.h
+++ b/src/Commands/Vision/HorizontalAlign.h
@@ -30,9 +30,11 @@ private:
 	const double TARGET_ASPECT = 1.66/1.00; //Aspect ratio of game-target (it's 1'8" x 1')
 	const int SCREEN_CENTER_X = 320; //Center of the screen. This is the point to which we will rotate
 								     //using PID.
+    const int PIXEL_TOLERANCE = 15;
+    const int TICK_TOLERANCE = 5;
 
-	const double ROT_SPEED_CAP = 0.8;
-	const double ROT_SPEED_MIN = 0.3;
+	const double ROT_SPEED_CAP = 0.4;
+	const double ROT_SPEED_MIN = 0.0;
 
 	int lastTargetDir = -1;
 	int lastCenter = 0;

--- a/src/OI.cpp
+++ b/src/OI.cpp
@@ -14,7 +14,8 @@
 #include "Commands/Internal/LEDOnOff.h"
 
 std::unique_ptr<JoystickButton> OI::grab_button;
-std::unique_ptr<JoystickButton> OI::align_button;
+std::unique_ptr<JoystickButton> OI::align_left;
+std::unique_ptr<JoystickButton> OI::align_right;
 std::unique_ptr<JoystickButton> OI::intake_button;
 std::unique_ptr<JoystickButton> OI::intake_clear_button;
 std::unique_ptr<JoystickButton> OI::shift_up;
@@ -24,10 +25,12 @@ std::unique_ptr<JoystickButton> OI::led_power;
 
 OI::OI() {
     gunner.reset(new lib612::SmoothController(PORTS::OI::gunner_joyport));
-    grab_button = std::make_unique<JoystickButton>(gunner.get(), 5); //left bumper
-    grab_button->WhenPressed(new Grab()); //Not on robot
-    align_button = std::make_unique<JoystickButton>(gunner.get(), 6); //right bumper
-    align_button->WhenPressed(new AutoAlign(HorizontalFind::RIGHT));
+    //grab_button = std::make_unique<JoystickButton>(gunner.get(), 5); //left bumper
+    //grab_button->WhenPressed(new Grab()); //Not on robot
+    align_left = std::make_unique<JoystickButton>(gunner.get(), 2); //B button
+    align_left->WhenPressed(new AutoAlign(HorizontalFind::RIGHT));
+    align_right = std::make_unique<JoystickButton>(gunner.get(), 3);
+    align_right->WhenPressed(new AutoAlign(HorizontalFind::LEFT));
 
     driver.reset(new lib612::SmoothController(PORTS::OI::driver_joyport));
     shift_up = std::make_unique<JoystickButton>(driver.get(), 1); //A button

--- a/src/OI.h
+++ b/src/OI.h
@@ -12,7 +12,8 @@ public:
     OI();
 
     static std::unique_ptr<JoystickButton> grab_button;
-    static std::unique_ptr<JoystickButton> align_button;
+    static std::unique_ptr<JoystickButton> align_left;
+    static std::unique_ptr<JoystickButton> align_right;
     static std::unique_ptr<JoystickButton> intake_button;
     static std::unique_ptr<JoystickButton> intake_clear_button;
     static std::unique_ptr<JoystickButton> shift_up;

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -41,6 +41,7 @@ void Robot::RobotInit() {
     intake = std::make_shared<Intake>();
     climber = std::make_shared<Climber>();
     shifter_subsys = std::make_shared<Shifter>();
+    vision = std::make_shared<Vision>();
     leds = std::make_shared<LEDs>();
     //Put this last
     oi = std::make_unique<OI>();
@@ -116,16 +117,20 @@ void Robot::TeleopInit() {
 
 void Robot::TeleopPeriodic() {
     //std::cout << "Robot.cpp: " << __LINE__ << std::endl;
+    if(oi->getdriver()->GetBackButton())
+        RobotMap::shooter_l->ClearIaccum();
+    vision->PullValues();
     Scheduler::GetInstance()->Run();
     //std::cout << "Robot.cpp: " << __LINE__ << std::endl;
 }
 
 void Robot::TestInit() {
-    testshooter->Start();
+    //testshooter->Start();
 }
 
 void Robot::TestPeriodic() {
-    if (oi->getgunner()->GetAButton()) {
+    //A = P, B = I, X = D, Y = f
+    /*if (oi->getgunner()->GetAButton()) {
         if(oi->getgunner()->GetBumper(frc::GenericHID::kLeftHand))
             frc::SmartDashboard::PutNumber("Test Shooter P", frc::SmartDashboard::GetNumber("Test Shooter P", 0) - 0.01);
         else
@@ -148,8 +153,7 @@ void Robot::TestPeriodic() {
             frc::SmartDashboard::PutNumber("Test Shooter F", frc::SmartDashboard::GetNumber("Test Shooter F", 0) - 0.01);
         else
             frc::SmartDashboard::PutNumber("Test Shooter F", frc::SmartDashboard::GetNumber("Test Shooter F", 0) + 0.01);
-    }
-
+    }*/
     Scheduler::GetInstance()->Run();
 }
 

--- a/src/Subsystems/Shooter.cpp
+++ b/src/Subsystems/Shooter.cpp
@@ -6,7 +6,7 @@
 Shooter::Shooter() :
         Subsystem("Shooter") {
     //talon = RobotMap::talon_shoot;
-    RobotMap::shooter_l->SetPID(SmartDashboard::GetNumber("Test Shooter P", 0), SmartDashboard::GetNumber("Test Shooter I", 0), SmartDashboard::GetNumber("Test Shooter D", 0), SmartDashboard::GetNumber("Test Shooter F", 0.037));
+    RobotMap::shooter_l->SetPID(0, 0, 0, 0);
     //get values from connected cimcoder
     RobotMap::shooter_l->SetFeedbackDevice(CANTalon::FeedbackDevice::CtreMagEncoder_Relative);
     //allows SetSetpoint to apply to speed from cimcoder and not from
@@ -16,9 +16,14 @@ Shooter::Shooter() :
     RobotMap::shooter_l->SelectProfileSlot(0);
     RobotMap::shooter_r->SetTalonControlMode(CANTalon::TalonControlMode::kFollowerMode);
     RobotMap::shooter_r->Set(PORTS::CAN::shooter_talon_right);
+    frc::SmartDashboard::PutNumber("Shooter I Zone", 0);
 
     lib612::Networking::AddFunction([](){
         frc::SmartDashboard::PutNumber("Shooter speed", RobotMap::shooter_l->GetSpeed());
+        frc::SmartDashboard::PutNumber("I Error", RobotMap::shooter_l->GetIaccum());
+        frc::SmartDashboard::PutNumber("I Zone", RobotMap::shooter_l->GetIzone());
+        frc::SmartDashboard::PutNumber("Error", RobotMap::shooter_l->GetClosedLoopError());
+        frc::SmartDashboard::PutNumber("Shooter voltage", RobotMap::shooter_l->GetOutputVoltage());
     });
 }
 
@@ -28,6 +33,7 @@ void Shooter::InitDefaultCommand() {
 
 void Shooter::Spin(float speed) {
     RobotMap::shooter_l->Set(speed);
+    RobotMap::shooter_l->SetIzone((unsigned)frc::SmartDashboard::GetNumber("Shooter I Zone", 0));
     RobotMap::shooter_r->Set(RobotMap::shooter_l->GetDeviceID());
     //RobotMap::shooter_r->Set(PORTS::CAN::shooter_talon_left);
 }


### PR DESCRIPTION
Changes:

**Shooter**

* The same as test code from Sunday.

**Vision**

* Absolute tolerance decreased

* Minimum speed unimplemented

* Timeout of 5 seconds set 

* A and B buttons on gunner now align left and right.

Possible bugs:

1. Alice was not able to completely align to the target much of the time.  I believe this is because I was testing on a wood floor (too much friction for small changes) and that Alice lacks a dropped center wheel to pivot properly. It should work fine on Chuck but its something to watch for

1. Sometimes, I could only align the robot with the same command (left or right) once. I concluded this is because the code already considered itself on target but there may be something else going on

